### PR TITLE
fix - removed const that breaks safari

### DIFF
--- a/dist/g3.js
+++ b/dist/g3.js
@@ -10,7 +10,7 @@ if(typeof(g3) === 'undefined') {
 	window.g3 = defineg3();
 }
 
-const DEBUG = false;
+var DEBUG = false;
 
 
 

--- a/src/const.js
+++ b/src/const.js
@@ -1,1 +1,1 @@
-const DEBUG = false;
+var DEBUG = false;


### PR DESCRIPTION
The stray const keyword is not allow in 'strict' mode and causes an error Safari.
Plots then fail to load.
